### PR TITLE
:sparkles: Changement de langue sur les pages de tag

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(ls:*)",
       "Bash(tree:*)",
       "Bash(find:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(rm:*)"
     ],
     "deny": []
   }

--- a/src/components/layout/header/page-mappers/tag-mapper.ts
+++ b/src/components/layout/header/page-mappers/tag-mapper.ts
@@ -25,16 +25,25 @@ export class TagMapper implements UrlMapper {
     let englishTag: string | null = null;
     let frenchTag: string | null = null;
     
-    // Chercher le tag en une seule itération sur les clés de traduction
-    for (const key of Object.keys(englishTranslations)) {
+    // Créer un ensemble de toutes les clés possibles des deux langues
+    const allKeys = new Set([
+      ...Object.keys(englishTranslations),
+      ...Object.keys(frenchTranslations)
+    ]);
+    
+    // Chercher le tag en itérant sur toutes les clés possibles
+    for (const key of allKeys) {
       const englishValue = englishTranslations[key as keyof typeof englishTranslations];
       const frenchValue = frenchTranslations[key as keyof typeof frenchTranslations];
       
-      if (englishValue === currentTag) {
+      // Vérifier si la valeur anglaise correspond et si la traduction française existe
+      if (englishValue === currentTag && frenchValue !== undefined) {
         englishTag = englishValue;
         frenchTag = frenchValue;
         break;
-      } else if (frenchValue === currentTag) {
+      } 
+      // Vérifier si la valeur française correspond et si la traduction anglaise existe
+      else if (frenchValue === currentTag && englishValue !== undefined) {
         englishTag = englishValue;
         frenchTag = frenchValue;
         break;

--- a/src/components/layout/header/page-mappers/tag-mapper.ts
+++ b/src/components/layout/header/page-mappers/tag-mapper.ts
@@ -25,29 +25,27 @@ export class TagMapper implements UrlMapper {
     let englishTag: string | null = null;
     let frenchTag: string | null = null;
     
-    // Chercher dans les traductions anglaises
-    for (const [key, value] of Object.entries(englishTranslations)) {
-      if (value === currentTag) {
-        englishTag = value;
-        frenchTag = frenchTranslations[key as keyof typeof frenchTranslations];
+    // Chercher le tag en une seule itération sur les clés de traduction
+    for (const key of Object.keys(englishTranslations)) {
+      const englishValue = englishTranslations[key as keyof typeof englishTranslations];
+      const frenchValue = frenchTranslations[key as keyof typeof frenchTranslations];
+      
+      if (englishValue === currentTag) {
+        englishTag = englishValue;
+        frenchTag = frenchValue;
         break;
-      }
-    }
-    
-    // Si pas trouvé, chercher dans les traductions françaises
-    if (!englishTag) {
-      for (const [key, value] of Object.entries(frenchTranslations)) {
-        if (value === currentTag) {
-          frenchTag = value;
-          englishTag = englishTranslations[key as keyof typeof englishTranslations];
-          break;
-        }
+      } else if (frenchValue === currentTag) {
+        englishTag = englishValue;
+        frenchTag = frenchValue;
+        break;
       }
     }
     
     // Fallback si le tag n'est pas trouvé dans les traductions
     if (!englishTag || !frenchTag) {
-      console.warn(`Tag "${currentTag}" not found in translations, using normalized version`);
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(`Tag "${currentTag}" not found in translations, using normalized version`);
+      }
       const normalizedTag = normalizeTagForUrl(currentTag);
       return {
         en: `/tag/${normalizedTag}`,

--- a/src/components/layout/header/page-mappers/tag-mapper.ts
+++ b/src/components/layout/header/page-mappers/tag-mapper.ts
@@ -1,6 +1,7 @@
-import type { UrlMapper, PageInfo } from "../page-detectors/types";
+import type { PageInfo, UrlMapper } from "../page-detectors/types";
 import { isTagPageInfo } from "../page-detectors/types";
 import { normalizeTagForUrl } from "@/lib/article/tag-utils";
+import { getTagTranslations } from "@/i18n/tag-translations";
 
 /**
  * Mapper d'URLs pour les pages de tags
@@ -14,12 +15,49 @@ export class TagMapper implements UrlMapper {
       return null;
     }
 
-    const tagPageInfo = pageInfo;
-    const normalizedTag = normalizeTagForUrl(tagPageInfo.tag);
+    const currentTag = pageInfo.tag;
+    
+    // Obtenir les traductions pour les deux langues
+    const englishTranslations = getTagTranslations("en");
+    const frenchTranslations = getTagTranslations("fr");
+    
+    // Trouver le tag dans les traductions anglaises et françaises
+    let englishTag: string | null = null;
+    let frenchTag: string | null = null;
+    
+    // Chercher dans les traductions anglaises
+    for (const [key, value] of Object.entries(englishTranslations)) {
+      if (value === currentTag) {
+        englishTag = value;
+        frenchTag = frenchTranslations[key as keyof typeof frenchTranslations];
+        break;
+      }
+    }
+    
+    // Si pas trouvé, chercher dans les traductions françaises
+    if (!englishTag) {
+      for (const [key, value] of Object.entries(frenchTranslations)) {
+        if (value === currentTag) {
+          frenchTag = value;
+          englishTag = englishTranslations[key as keyof typeof englishTranslations];
+          break;
+        }
+      }
+    }
+    
+    // Fallback si le tag n'est pas trouvé dans les traductions
+    if (!englishTag || !frenchTag) {
+      console.warn(`Tag "${currentTag}" not found in translations, using normalized version`);
+      const normalizedTag = normalizeTagForUrl(currentTag);
+      return {
+        en: `/tag/${normalizedTag}`,
+        fr: `/fr/tag/${normalizedTag}`,
+      };
+    }
 
     return {
-      en: `/tag/${normalizedTag}`,
-      fr: `/fr/tag/${normalizedTag}`,
+      en: `/tag/${normalizeTagForUrl(englishTag)}`,
+      fr: `/fr/tag/${normalizeTagForUrl(frenchTag)}`,
     };
   }
 }

--- a/src/components/layout/header/types.ts
+++ b/src/components/layout/header/types.ts
@@ -41,6 +41,11 @@ export interface ArticleLanguageContext {
   readonly isCategoryPage?: boolean;
   readonly categorySlug?: string;
   readonly categoryUrlMapping?: Record<string, string>;
+  
+  // Nouveaux champs pour les pages de tags
+  readonly isTagPage?: boolean;
+  readonly tagSlug?: string;
+  readonly tagUrlMapping?: Record<string, string>;
 }
 
 export interface LanguageUrlData {

--- a/src/test/components/layout/header/tag-mapper.test.ts
+++ b/src/test/components/layout/header/tag-mapper.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TagMapper } from "@/components/layout/header/page-mappers/tag-mapper";
+import type { TagPageInfo, PageInfo } from "@/components/layout/header/page-detectors/types";
+import type { TagTranslations } from "@/lib/article/tag-utils";
+
+// Mock the tag-translations module
+vi.mock("@/i18n/tag-translations", () => ({
+  getTagTranslations: vi.fn(),
+}));
+
+// Mock the tag-utils module
+vi.mock("@/lib/article/tag-utils", () => ({
+  normalizeTagForUrl: vi.fn((tag: string) => tag.toLowerCase().replace(/\s+/g, "-")),
+}));
+
+import { getTagTranslations } from "@/i18n/tag-translations";
+import { normalizeTagForUrl } from "@/lib/article/tag-utils";
+
+const mockGetTagTranslations = vi.mocked(getTagTranslations);
+const mockNormalizeTagForUrl = vi.mocked(normalizeTagForUrl);
+
+describe("TagMapper", () => {
+  let mapper: TagMapper;
+
+  beforeEach(() => {
+    mapper = new TagMapper();
+    vi.clearAllMocks();
+    
+    // Setup default mock behavior
+    mockNormalizeTagForUrl.mockImplementation((tag: string) => 
+      tag.toLowerCase().replace(/\s+/g, "-")
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("createUrlMapping with symmetric translations", () => {
+    beforeEach(() => {
+      mockGetTagTranslations.mockImplementation((lang: "en" | "fr") => {
+        if (lang === "en") {
+          return {
+            guide: "Guide",
+            optimization: "Optimization",
+            bestPractices: "Best Practices",
+            comparison: "Comparison",
+          };
+        } else {
+          return {
+            guide: "Guide",
+            optimization: "Optimisation", 
+            bestPractices: "Bonnes Pratiques",
+            comparison: "Comparaison",
+          };
+        }
+      });
+    });
+
+    it("should create correct URL mapping for English tag", () => {
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "Optimization",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      expect(result).toEqual({
+        en: "/tag/optimization",
+        fr: "/fr/tag/optimisation",
+      });
+    });
+
+    it("should create correct URL mapping for French tag", () => {
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "fr",
+        tag: "Bonnes Pratiques",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      expect(result).toEqual({
+        en: "/tag/best-practices",
+        fr: "/fr/tag/bonnes-pratiques",
+      });
+    });
+  });
+
+  describe("createUrlMapping with asymmetric translations (bug fix validation)", () => {
+    it("should handle case where key exists only in French translations", () => {
+      mockGetTagTranslations.mockImplementation((lang: "en" | "fr") => {
+        if (lang === "en") {
+          return {
+            guide: "Guide",
+            optimization: "Optimization",
+            bestPractices: "Best Practices",
+            // comparison missing in English
+          } as Record<string, string>;
+        } else {
+          return {
+            guide: "Guide",
+            optimization: "Optimisation",
+            bestPractices: "Bonnes Pratiques",
+            comparison: "Comparaison",
+            onlyInFrench: "Seulement en Français", // Key only in French
+          } as Record<string, string>;
+        }
+      });
+
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "fr",
+        tag: "Seulement en Français",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      // Should fall back to normalized version since no English equivalent
+      expect(result).toEqual({
+        en: "/tag/seulement-en-français",
+        fr: "/fr/tag/seulement-en-français",
+      });
+    });
+
+    it("should handle case where key exists only in English translations", () => {
+      mockGetTagTranslations.mockImplementation((lang: "en" | "fr") => {
+        if (lang === "en") {
+          return {
+            guide: "Guide",
+            optimization: "Optimization",
+            bestPractices: "Best Practices",
+            onlyInEnglish: "Only in English", // Key only in English
+          } as Record<string, string>;
+        } else {
+          return {
+            guide: "Guide",
+            optimization: "Optimisation",
+            bestPractices: "Bonnes Pratiques",
+            // onlyInEnglish missing in French
+          } as Record<string, string>;
+        }
+      });
+
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "Only in English",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      // Should fall back to normalized version since no French equivalent
+      expect(result).toEqual({
+        en: "/tag/only-in-english",
+        fr: "/fr/tag/only-in-english",
+      });
+    });
+
+    it("should handle case where value exists but corresponding translation is undefined", () => {
+      mockGetTagTranslations.mockImplementation((lang: "en" | "fr") => {
+        if (lang === "en") {
+          return {
+            guide: "Guide",
+            optimization: "Optimization",
+            partialKey: "English Value",
+          } as Record<string, string | undefined>;
+        } else {
+          return {
+            guide: "Guide",
+            optimization: "Optimisation",
+            partialKey: undefined, // Explicitly undefined
+          } as Record<string, string | undefined>;
+        }
+      });
+
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "English Value",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      // Should fall back to normalized version since French value is undefined
+      expect(result).toEqual({
+        en: "/tag/english-value",
+        fr: "/fr/tag/english-value",
+      });
+    });
+  });
+
+  describe("createUrlMapping with completely missing translations", () => {
+    beforeEach(() => {
+      mockGetTagTranslations.mockImplementation((lang: "en" | "fr") => {
+        if (lang === "en") {
+          return {
+            guide: "Guide",
+            optimization: "Optimization",
+            bestPractices: "Best Practices",
+            comparison: "Comparison",
+          };
+        } else {
+          return {
+            guide: "Guide", 
+            optimization: "Optimisation",
+            bestPractices: "Bonnes Pratiques",
+            comparison: "Comparaison",
+          };
+        }
+      });
+    });
+
+    it("should use fallback for unknown tag", () => {
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "Unknown Tag",
+      };
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      expect(result).toEqual({
+        en: "/tag/unknown-tag",
+        fr: "/fr/tag/unknown-tag",
+      });
+    });
+  });
+
+  describe("createUrlMapping edge cases", () => {
+    it("should return null for non-tag page info", () => {
+      const pageInfo = {
+        pageType: "article",
+        detectedLang: "en",
+      } as PageInfo;
+
+      const result = mapper.createUrlMapping(pageInfo);
+
+      expect(result).toBeNull();
+    });
+
+    it("should have correct pageType", () => {
+      expect(mapper.pageType).toBe("tag");
+    });
+  });
+
+  describe("production environment behavior", () => {
+    it("should not log warnings in production", () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "production";
+      
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      
+      mockGetTagTranslations.mockImplementation(() => ({
+        guide: "Guide",
+        optimization: "Optimization", 
+        bestPractices: "Best Practices",
+        comparison: "Comparison",
+      }));
+
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "Unknown Tag",
+      };
+
+      mapper.createUrlMapping(pageInfo);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      
+      process.env.NODE_ENV = originalEnv;
+      consoleSpy.mockRestore();
+    });
+
+    it("should log warnings in non-production", () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      
+      mockGetTagTranslations.mockImplementation(() => ({
+        guide: "Guide",
+        optimization: "Optimization",
+        bestPractices: "Best Practices", 
+        comparison: "Comparison",
+      }));
+
+      const pageInfo: TagPageInfo = {
+        pageType: "tag",
+        detectedLang: "en",
+        tag: "Unknown Tag",
+      };
+
+      mapper.createUrlMapping(pageInfo);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Tag "Unknown Tag" not found in translations, using normalized version'
+      );
+      
+      process.env.NODE_ENV = originalEnv;
+      consoleSpy.mockRestore();
+    });
+  });
+}); 

--- a/verify-tag-system.md
+++ b/verify-tag-system.md
@@ -1,0 +1,102 @@
+# Vérification du système de pages de tags
+
+## Modifications effectuées pour corriger le switch de langue sur les pages de tags
+
+### 1. Types mis à jour
+
+✅ **ArticleLanguageContext** dans `src/components/layout/header/types.ts` :
+- Ajout de `isTagPage?: boolean`
+- Ajout de `tagSlug?: string` 
+- Ajout de `tagUrlMapping?: Record<string, string>`
+
+### 2. Système de détection des pages de tags
+
+✅ **TagDetector** créé dans `src/components/layout/header/page-detectors/tag-detector.ts` :
+- Détecte les URLs `/tag/[tag]` et `/fr/tag/[tag]`
+- Extrait le tag depuis l'URL
+- Dénormalise le slug vers le nom de tag réel
+
+✅ **TagMapper** créé dans `src/components/layout/header/page-mappers/tag-mapper.ts` :
+- Génère les URLs correspondantes dans toutes les langues
+- Utilise `normalizeTagForUrl` pour créer les URLs
+
+✅ **PageDetectionManager** mis à jour dans `src/components/layout/header/page-utils.ts` :
+- Enregistre le TagDetector et TagMapper
+- Ajoute le support pour les pages de type "tag"
+- Gère les pages de tags dans `analyzeLanguageContextUnified`
+
+### 3. Génération des URLs de langue
+
+✅ **analyzeLanguageContext** mis à jour dans `src/components/layout/header/server-utils.ts` :
+- Inclut les propriétés de tags dans la conversion vers l'ancien format
+
+✅ **analyzeLanguageContextPure** mis à jour dans `src/components/layout/header/article-utils.ts` :
+- Gère les pages de type "tag"
+- Génère le mapping d'URLs pour les tags
+- Ajoute `isTagPage: false` dans tous les fallbacks
+
+✅ **generateContextualLanguageUrls** mis à jour dans `src/components/layout/header/article-utils.ts` :
+- Ajoute une clause pour les pages de tags (`context.isTagPage && context.tagUrlMapping`)
+- Génère les URLs de langue pour les pages de tags
+
+### 4. Fallbacks et gestion d'erreur
+
+✅ **createArticleFallbackContext** mis à jour dans `src/components/layout/header/server-utils.ts` :
+- Ajoute `isTagPage: false` dans les contextes de fallback
+
+## Flux de fonctionnement attendu
+
+1. **URL de tag visitée** (ex: `/tag/guide` ou `/fr/tag/optimisation`)
+
+2. **Détection** : `TagDetector.isPageType()` retourne `true`
+
+3. **Extraction** : `TagDetector.extractPageInfo()` retourne :
+   ```typescript
+   {
+     pageType: "tag",
+     tag: "Guide", // ou "Optimisation" 
+     detectedLang: "en" // ou "fr"
+   }
+   ```
+
+4. **Mapping** : `TagMapper.createUrlMapping()` retourne :
+   ```typescript
+   {
+     en: "/tag/guide",
+     fr: "/fr/tag/guide" // ou "/fr/tag/optimisation"
+   }
+   ```
+
+5. **Contexte** : `analyzeLanguageContextUnified()` retourne :
+   ```typescript
+   {
+     isArticlePage: false,
+     isCategoryPage: false,
+     isTagPage: true,
+     tagSlug: "Guide",
+     tagUrlMapping: { en: "/tag/guide", fr: "/fr/tag/guide" },
+     detectedLang: "en",
+     pageType: "tag"
+   }
+   ```
+
+6. **URLs de langue** : `generateContextualLanguageUrls()` utilise `context.tagUrlMapping` pour générer les URLs du switch de langue
+
+## Points de validation
+
+- ✅ Les interfaces TypeScript incluent les propriétés de tags
+- ✅ Le système de détection reconnaît les pages de tags
+- ✅ Le mapper génère les URLs correctes
+- ✅ La fonction de génération d'URLs de langue gère les tags
+- ✅ Tous les fallbacks incluent `isTagPage: false`
+
+## Test manuel recommandé
+
+1. Naviguer vers une page de tag (ex: `/tag/guide`)
+2. Vérifier que le switch de langue affiche les bonnes options
+3. Cliquer sur le switch pour passer en français
+4. Vérifier que l'URL devient `/fr/tag/guide`
+5. Vérifier que le contenu est bien en français
+6. Répéter en sens inverse
+
+La correction devrait maintenant permettre au switch de langue de fonctionner correctement sur les pages de tags.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout du support du changement de langue pour les pages de tags, avec détection automatique et génération d’URL bilingues pour chaque tag.
  * Le sélecteur de langue fonctionne désormais correctement sur les pages de tags, en adaptant les URLs et les contenus selon la langue choisie.

* **Documentation**
  * Ajout d’une documentation détaillant le fonctionnement du système de changement de langue sur les pages de tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->